### PR TITLE
Added helper variable, removed extra slash

### DIFF
--- a/_layouts/category_index.html
+++ b/_layouts/category_index.html
@@ -2,13 +2,10 @@
 layout: default
 ---
 
-<h1 class="category">{{ page.title }} <a href="javascript:window.history.back();">&laquo;</a></h1>
-<ul class="posts">
-
-{% if page.title == 'Categories:' %}
+{% if page.category_root %}
 	{% include taxonomy_sort.html source=site.categories %}
 	{% for taxonomy in sortedtaxonomies %}
-		<h2><a href="{{ page.url | prepend: base_url | replace: "/index.html", "" }}/{{ taxonomy }}/">{{ taxonomy }}</a></h2>
+		<h2><a href="{{ page.url | prepend: base_url | replace: "/index.html", "" }}{{ taxonomy }}/">{{ taxonomy }}</a></h2>
 	{% endfor %}
 {% else %}
 	{% assign catpages = site.categories[page.category] | sort: 'date' %}

--- a/_layouts/category_index.html
+++ b/_layouts/category_index.html
@@ -8,7 +8,7 @@ layout: default
 {% if page.category_root %}
 	{% include taxonomy_sort.html source=site.categories %}
 	{% for taxonomy in sortedtaxonomies %}
-		<h2><a href="{{ page.url | prepend: base_url | replace: "/index.html", "" }}{{ taxonomy }}/">{{ taxonomy }}</a></h2>
+		<h2><a href="{{ page.url | prepend: base_url | replace: "/index.html", "" | append: "/" | replace: "//", "/" }}{{ taxonomy }}/">{{ taxonomy }}</a></h2>
 	{% endfor %}
 {% else %}
 	{% assign catpages = site.categories[page.category] | sort: 'date' %}

--- a/_layouts/category_index.html
+++ b/_layouts/category_index.html
@@ -2,6 +2,9 @@
 layout: default
 ---
 
+<h1 class="category">{{ page.title }} <a href="javascript:window.history.back();">&laquo;</a></h1>
+<ul class="posts">
+
 {% if page.category_root %}
 	{% include taxonomy_sort.html source=site.categories %}
 	{% for taxonomy in sortedtaxonomies %}

--- a/_plugins/category_pages.rb
+++ b/_plugins/category_pages.rb
@@ -16,8 +16,10 @@ module Jekyll
         self.data['category'] = category
         category_title_prefix = site.config['category_title_prefix'] || 'Category: '
         self.data['title'] = "#{category_title_prefix}#{category}"
+        self.data['category_root'] = false # juzraai
       else
         self.data['title'] = 'Categories:'
+        self.data['category_root'] = true # juzraai
       end
 
     end


### PR DESCRIPTION
`category_root` variable helps layout to decide whether to render a category list or a post list - without knowing the title of the category list page (old version). This way, title of the category list can be
edited at only one place. :)

Also there was an extra slash in taxonomy link which produced a "/categories//category-name/" like URL.

Awesome plugin anyway! :)
